### PR TITLE
Use correct number of flash pages in XN file

### DIFF
--- a/examples/app_usb_audio_awe/src/core/xk-audio-316-mc-700.xn
+++ b/examples/app_usb_audio_awe/src/core/xk-audio-316-mc-700.xn
@@ -81,7 +81,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="8192">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
I was getting the yes/no warning prompt when flashing my board, so this XN file must have been copied from before this was fixed in sw_usb_audio.