### PR TITLE
platform.h was included via one of the lib_xcore headers in XTC 15.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_awe Change Log
 ==================
 
+UNRELEASED
+----------
+
+  * FIXED:   Missing header inclusion
+
 1.0.1
 -----
 

--- a/lib_awe/src/awe_ffs_rpc.c
+++ b/lib_awe/src/awe_ffs_rpc.c
@@ -1,5 +1,6 @@
 // Copyright 2023-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#include <platform.h>
 #include <xcore/channel.h>
 #include <xcore/hwtimer.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes the port definition error in #78, but the linker error still happens with XTC 15.3.0.