### PR TITLE
Fix linker failure with XTC 15.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
   * FIXED:   Missing header inclusion
+  * FIXED:   Linker failure with XTC 15.3.0
 
 1.0.1
 -----

--- a/tests/test_basic/src/test_awe_basic.c
+++ b/tests/test_basic/src/test_awe_basic.c
@@ -82,6 +82,7 @@ void awe_test(uint32_t *msg_to_awe_buffer, int msg_len, chanend_t c_tuning_from_
 
 DECLARE_JOB(awe_main_wrapper, (chanend_t, chanend_t, chanend_t));
 #pragma stackfunction 5000
+__attribute__((noinline))
 void awe_main_wrapper(chanend_t c_tuning_from_host, chanend_t c_tuning_to_host, chanend_t c_data){
     awe_xcore_main(c_tuning_from_host, c_tuning_to_host, c_data);
 }

--- a/tests/test_ffs_awb_device/src/test_ffs_awb.c
+++ b/tests/test_ffs_awb_device/src/test_ffs_awb.c
@@ -61,6 +61,7 @@ void awe_test(chanend_t c_tuning_from_host, chanend_t c_tuning_to_host){
 
 DECLARE_JOB(awe_main_wrapper, (chanend_t, chanend_t, chanend_t, chanend_t));
 #pragma stackfunction 5000
+__attribute__((noinline))
 void awe_main_wrapper(chanend_t c_tuning_from_host, chanend_t c_tuning_to_host, chanend_t c_data, chanend_t c_ffs_rpc){
     init_ffs_rpc_client_chanend(c_ffs_rpc);
     awe_xcore_main(c_tuning_from_host, c_tuning_to_host, c_data);

--- a/tests/test_ffs_rpc/src/test_awe_ffs_rpc.c
+++ b/tests/test_ffs_rpc/src/test_awe_ffs_rpc.c
@@ -19,6 +19,7 @@
 
 DECLARE_JOB(awe_main_wrapper, (chanend_t, chanend_t, chanend_t, chanend_t));
 #pragma stackfunction 8000
+__attribute__((noinline))
 void awe_main_wrapper(chanend_t c_tuning_from_host, chanend_t c_tuning_to_host, chanend_t c_data, chanend_t c_ffs_rpc){
     init_ffs_rpc_client_chanend(c_ffs_rpc);
     awe_xcore_main(c_tuning_from_host, c_tuning_to_host, c_data);

--- a/tests/test_xawe_if/src/test_xawe_if.c
+++ b/tests/test_xawe_if/src/test_xawe_if.c
@@ -124,6 +124,7 @@ void awe_test(chanend_t c_data){
 
 DECLARE_JOB(awe_main_wrapper, (chanend_t, chanend_t, chanend_t));
 #pragma stackfunction 5000
+__attribute__((noinline))
 void awe_main_wrapper(chanend_t c_tuning_from_host, chanend_t c_tuning_to_host, chanend_t c_data){
     awe_xcore_main(c_tuning_from_host, c_tuning_to_host, c_data);
 }


### PR DESCRIPTION
A change in lib_xcore in XTC 15.3.0 caused `awe_main_wrapper` to be inlined into the PAR_JOBS, where it previously wasn't inlined. As a result, the `#pragma stackfunction 5000` has no effect and the stack size becomes incalculable. The fix here is to prevent `awe_main_wrapper` from being inlined. I've added this attribute to all the relevant functions in the tests which could be affected by this to avoid more occurrences of this error in the future.

Fixes #78